### PR TITLE
added link to taxize book to both the readme and vignette

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -52,6 +52,7 @@ wm_records_date('2016-12-23T05:59:45+00:00')
 ```
 
 by a taxonomic name
+([taxize book](https://ropensci.github.io/taxize-book/))
 
 ```{r}
 wm_records_name(name = 'Platanista gangetica')

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ wm_records_date('2016-12-23T05:59:45+00:00')
 ```
 
 by a taxonomic name
-
+([taxize book](https://ropensci.github.io/taxize-book/))
 
 ```r
 wm_records_name(name = 'Platanista gangetica')

--- a/vignettes/worrms_vignette.Rmd
+++ b/vignettes/worrms_vignette.Rmd
@@ -63,7 +63,7 @@ wm_records_date('2016-12-23T05:59:45+00:00')
 ```
 
 by a taxonomic name
-
+([taxize book](https://ropensci.github.io/taxize-book/))
 
 ```r
 wm_records_name(name = 'Platanista gangetica')


### PR DESCRIPTION
Added link to the taxize book (https://ropensci.github.io/taxize-book/)to both the readme and the vignette.

## Description
Added the link before the example.

## Related Issue
This relates to issue #12 
