### PR TITLE
Fix badges

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -13,11 +13,11 @@ knitr::opts_chunk$set(
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![cran checks](https://cranchecks.info/badges/worst/worrms)](https://cranchecks.info/pkgs/worrms)
-[![R-check](https://github.com/ropensci/worrms/workflows/R-check/badge.svg)](https://github.com/ropensci/worrms/actions?query=workflow%3AR-check)
+[![R-check](https://github.com/ropensci/worrms/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ropensci/worrms/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/ropensci/worrms/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/worrms)
 [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/worrms)](https://github.com/metacran/cranlogs.app)
 [![cran version](https://www.r-pkg.org/badges/version/worrms)](https://cran.r-project.org/package=worrms)
+[![cran checks](https://badges.cranchecks.info/worst/worrms.svg)](https://cran.r-project.org/web/checks/check_results_worrms.html)
 
 `worrms` is a R client for the World Register of Marine Species
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,49 @@
-worrms
-======
-
-
+# worrms
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![cran checks](https://cranchecks.info/badges/worst/worrms)](https://cranchecks.info/pkgs/worrms)
-[![R-check](https://github.com/ropensci/worrms/workflows/R-check/badge.svg)](https://github.com/ropensci/worrms/actions?query=workflow%3AR-check)
+[![Project Status: Active – The project has reached a stable, usable
+state and is being actively
+developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![R-check](https://github.com/ropensci/worrms/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ropensci/worrms/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/ropensci/worrms/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/worrms)
-[![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/worrms)](https://github.com/metacran/cranlogs.app)
-[![cran version](https://www.r-pkg.org/badges/version/worrms)](https://cran.r-project.org/package=worrms)
+[![rstudio mirror
+downloads](https://cranlogs.r-pkg.org/badges/worrms)](https://github.com/metacran/cranlogs.app)
+[![cran
+version](https://www.r-pkg.org/badges/version/worrms)](https://cran.r-project.org/package=worrms)
+[![cran
+checks](https://badges.cranchecks.info/worst/worrms.svg)](https://cran.r-project.org/web/checks/check_results_worrms.html)
 
 `worrms` is a R client for the World Register of Marine Species
 
-* World Register of Marine Species (WoRMS) http://www.marinespecies.org/
-* WoRMS REST API docs: http://www.marinespecies.org/rest/
+-   World Register of Marine Species (WoRMS)
+    <http://www.marinespecies.org/>
+-   WoRMS REST API docs: <http://www.marinespecies.org/rest/>
 
-See the taxize book (https://taxize.dev) for taxonomically focused work
-in this and similar packages.
+See the taxize book (<https://taxize.dev>) for taxonomically focused
+work in this and similar packages.
 
 ## Installation
 
 More stable CRAN version
 
-
-```r
-install.packages("worrms")
-```
+    install.packages("worrms")
 
 Development version
 
+    remotes::install_github("ropensci/worrms")
 
-```r
-remotes::install_github("ropensci/worrms")
-```
-
-
-```r
-library("worrms")
-```
+    library("worrms")
 
 ## Meta
 
-* Please [report any issues or bugs](https://github.com/ropensci/worrms/issues).
-* License: MIT
-* Get citation information for `worrms` in R doing `citation(package = 'worrms')`
-* Please note that this package is released with a [Contributor Code of Conduct](https://ropensci.org/code-of-conduct/). By contributing to this project, you agree to abide by its terms.
+-   Please [report any issues or
+    bugs](https://github.com/ropensci/worrms/issues).
+-   License: MIT
+-   Get citation information for `worrms` in R doing
+    `citation(package = 'worrms')`
+-   Please note that this package is released with a [Contributor Code
+    of Conduct](https://ropensci.org/code-of-conduct/). By contributing
+    to this project, you agree to abide by its terms.
 
 [![rofooter](https://ropensci.org/public_images/github_footer.png)](https://ropensci.org)


### PR DESCRIPTION
This fixes the `workflows/R-CMD-check` and cranchecks.info badges in the README.